### PR TITLE
Add GitHub CI Publish Workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish
+        env:
+          NPM_ACCESS_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}


### PR DESCRIPTION
Adding the GitHub CI Publish Workflow for the Node library so that when we push to master it'll publish the package.