### PR TITLE
Add version select

### DIFF
--- a/.github/clean.rb
+++ b/.github/clean.rb
@@ -5,7 +5,8 @@ ALLOW_LIST = [
   ".github",
   ".openapi-generator-ignore",
   "LICENSE",
-  "openapi"
+  "openapi",
+  "openapitools.json"
 ].freeze
 
 ::Dir.each_child(::Dir.pwd) do |source|

--- a/.github/version.rb
+++ b/.github/version.rb
@@ -1,3 +1,19 @@
 require "yaml"
-config = ::YAML.load(File.read("openapi/config.yml"))
+config = ::YAML.load(::File.read("openapi/config.yml"))
+major, minor, patch = config["npmVersion"].split(".")
+
+case ARGV[0]
+when "major"
+  major = major.succ
+  minor = 0
+  patch = 0
+when "minor"
+  minor = minor.succ
+  patch = 0
+when "patch"
+  patch = patch.succ
+end
+
+config["npmVersion"] = "#{major}.#{minor}.#{patch}"
+::File.open("openapi/config.yml", 'w') { |file| ::YAML.dump(config, file) }
 puts config["npmVersion"]


### PR DESCRIPTION
Adds the ability to choose a semantic version (major, minor, patch) when
updating the library.

Also adds the `openapitools.json` file to the allowlist as recommended
by the `openapi-generator-cli` README.